### PR TITLE
Added support to git commit the version

### DIFF
--- a/lib/puppet_blacksmith/git.rb
+++ b/lib/puppet_blacksmith/git.rb
@@ -13,10 +13,10 @@ module Blacksmith
       exec_git "tag v#{version}"
     end
 
-    def commit_modulefile!
+    def commit_modulefile!(version)
       files = Blacksmith::Modulefile::FILES.select {|f| File.exists?(File.join(@path,f))}
       s = exec_git "add #{files.join(" ")}"
-      s += exec_git "commit -m '[blacksmith] Bump version'"
+      s += exec_git "commit -m '[blacksmith] Bump version to #{version}'"
       s
     end
 

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -17,7 +17,8 @@ namespace :module do
 
   desc "Bump version and git commit"
   task :bump_commit => :bump do
-    Blacksmith::Git.new.commit_modulefile!
+    m = Blacksmith::Modulefile.new
+    Blacksmith::Git.new.commit_modulefile!(m.version)
   end
 
   desc "Push module to the Puppet Forge"

--- a/spec/puppet_blacksmith/git_spec.rb
+++ b/spec/puppet_blacksmith/git_spec.rb
@@ -32,7 +32,7 @@ describe 'Blacksmith::Git' do
       end
 
       it "should commit the metadata file" do
-        expect(subject.commit_modulefile!).to match(/\[blacksmith\] Bump version/)
+        expect(subject.commit_modulefile!(version)).to match(/\[blacksmith\] Bump version to #{version}/)
       end
     end
 


### PR DESCRIPTION
Adds support to the rake module:bump_commit task so that the
version number is recorded in the git commit message.
