### PR TITLE
Allow setting credentials info via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Configure your credentials in `~/.puppetforge.yml`
     password: mypassword
 
 
+Or set the equivalent environment variables in your shell
+
+    export BLACKSMITH_FORGE_URL=https://forgeapi.puppetlabs.com
+    export BLACKSMITH_FORGE_USERNAME=myuser
+    export BLACKSMITH_FORGE_PASSWORD=mypassword
+
+
 Add the require instructions for blacksmith and the puppetlabs_spec_helper to the Rakefile
 
     # Rakefile


### PR DESCRIPTION
Prior to this a user could set the credential information (username,
password, and url of the forge) via a file located at
~/.puppetforge.yml.

This commit allows users to set the environment variables
 - BLACKSMITH_FORGE_URL
 - BLACKSMITH_FORGE_USERNAME
 - BLACKSMITH_FORGE_PASSWORD
to set the url, username, and password values respectively.

This eases publishing under multiple usernames on the forge as well as
pushing to multiple forges by users (and CI systems) by allowing a
method of setting variables that is not per user wide (an issue with a
credentials file in the user's home directory).

Environment variables will take precedence over values set in a
credentials file.