### PR TITLE
Add version related commands for displaying current or next versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Rake tasks included:
 | module:push        | Push module to the Puppet Forge |
 | module:release     | Release the Puppet module, doing a clean, build, tag, push, bump_commit and git push |
 | module:tag         | Git tag with the current module version |
+| module:version     | Get the current module version |
+| module:version:next | Get the next patch module version |
+| module:version:next:patch | Get the next patch module version |
+| module:version:next:minor | Get the next minor module version |
+| module:version:next:major | Get the next major module version |
 
 ### Full release
 

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -26,6 +26,11 @@ module Blacksmith
         'bump:patch',
         'bump:full',
         :tag,
+        :version,
+        'version:next',
+        'version:next:major',
+        'version:next:minor',
+        'version:next:patch',
         :bump_commit,
         'bump_commit:major',
         'bump_commit:minor',
@@ -65,6 +70,28 @@ module Blacksmith
           git = Blacksmith::Git.new
           git.tag_pattern = @tag_pattern
           git.tag!(m.version)
+        end
+
+        namespace :version do
+          desc "Get next module version"
+          task :next do
+            m = Blacksmith::Modulefile.new
+            puts m.increase_version(m.version, 'patch')
+          end
+
+          [:major, :minor, :patch].each do |level|
+            desc "Get the next #{level.upcase} version"
+            task "next:#{level}".to_sym do
+              m = Blacksmith::Modulefile.new
+              puts m.increase_version(m.version, level)
+            end
+          end
+        end
+
+        desc "Get current module version"
+        task :version do
+          m = Blacksmith::Modulefile.new
+          puts m.version
         end
 
         namespace :bump_commit do


### PR DESCRIPTION
Add 'version', 'version:next' and 'version:next:[patch|major|minor]' commands to output the current or next version of module.
Useful for wrapping Blacksmith with git flow for example.

The naming structure was the most sensible I could think of, however could equally use 'module:next_version', 'module:version_next' etc... 