### PR TITLE
update build status badge source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 puppet-blacksmith
 =================
 
-[![Build Status](https://maestro.maestrodev.com/api/v1/projects/67/compositions/326/badge/icon)](https://maestro.maestrodev.com/projects/67/compositions/326)
-[![Build Status](https://travis-ci.org/maestrodev/puppet-blacksmith.svg?branch=master)](https://travis-ci.org/maestrodev/puppet-blacksmith)
+[![Build Status](https://travis-ci.org/voxpupuli/puppet-blacksmith.svg?branch=master)](https://travis-ci.org/voxpupuli/puppet-blacksmith)
 
 Ruby Gem with several Puppet Module utilities
 


### PR DESCRIPTION
- Remove the link to https://maestro.maestrodev.com/projects/67/compositions/326, it doesn't seem to be active.
- Update the Travis URL to point to voxpupuli's namespace