### PR TITLE
(MODULES-4344) bump_to_version rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Rake tasks included:
 | module:bump_commit:minor  | Bump module version to the next minor version and git commit |
 | module:bump_commit:major  | Bump module version to the next major version and git commit |
 | module:bump_commit:full   | Bump module version to the version set in the BLACKSMITH_FULL_VERSION env variable and git commit |
+| module:bump_to_version\[:new\_version\] | Bump module version to _new\_version_ |
 | module:clean       | Runs clean again |
 | module:dependency[modulename, version] | Updates the module version of a specific dependency |
 | module:push        | Push module to the Puppet Forge |

--- a/lib/puppet_blacksmith/modulefile.rb
+++ b/lib/puppet_blacksmith/modulefile.rb
@@ -28,12 +28,16 @@ module Blacksmith
       metadata['version']
     end
 
-    def bump!(level = :patch)
-      new_version = increase_version(version, level)
+    def bump_to_version!(new_version)
       text = File.read(path)
       text = replace_version(text, new_version)
-      File.open(path, "w") {|file| file.puts text}
+      File.open(path,"w") { |file| file.puts text }
       new_version
+    end
+
+    def bump!(level = :patch)
+      new_version = increase_version(version, level)
+      bump_to_version!(new_version)
     end
 
     [:major, :minor, :patch, :full].each do |level|

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -57,6 +57,13 @@ module Blacksmith
           end
         end
 
+        desc "Bump module to specific version number"
+        task :bump_to_version, [:new_version] do |t, args|
+          m = Blacksmith::Modulefile.new
+          v = m.bump_to_version!(args[:new_version])
+          puts "Bumping version to #{args[:new_version]}"
+        end
+
         desc "Bump module version to the next patch"
         task :bump do
           m = Blacksmith::Modulefile.new

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -109,6 +109,10 @@ describe 'Blacksmith::Modulefile' do
 
   end
 
+  describe 'bump_to_version' do
+    it { expect(subject.bump_to_version!("1.0.0")).to eql("1.0.0") }
+  end
+
   describe 'increase_version' do
     it { expect(subject.increase_version("1.0.0")).to eql("1.0.1") }
     it { expect(subject.increase_version("1.0.1")).to eql("1.0.2") }


### PR DESCRIPTION
We would like the ability to change the modules version to any version. This new rake task goes around bump levels and accepts any version as a parameter.