### PR TITLE
(maint) remove ruby 1.9 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   # 2.2 is not supported by puppet https://tickets.puppetlabs.com/browse/PUP-3796
   - '2.1'
   - '2.0'
-  - '1.9'
 
 env:
   - PUPPET_VERSION="~> 3.7.0"


### PR DESCRIPTION
Extended maintenance of ruby 1.9.3 ended 2 years ago. And its blocking my other PR. AND puppet no longer supports it.