### PR TITLE
fix rake module release order

### DIFF
--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -125,7 +125,7 @@ module Blacksmith
         end
 
         desc "Release the Puppet module, doing a clean, build, tag, push, bump_commit and git push."
-        release_dependencies = @build ? [:clean, :build, :tag, :push, :bump_commit] : [:clean, :tag, :bump_commit]
+        release_dependencies = @build ? [:clean, :build, :bump_commit, :tag, :push] : [:clean, :bump_commit, :tag]
         task :release => release_dependencies do
           puts "Pushing to remote git repo"
           Blacksmith::Git.new.push!


### PR DESCRIPTION
When starting to use blacksmith to manage versioning of my puppet modules i ran into issue #38. This PR fixes the order of the release workflow.