### PR TITLE
convert git cmd strings to array

### DIFF
--- a/lib/puppet_blacksmith/git.rb
+++ b/lib/puppet_blacksmith/git.rb
@@ -48,6 +48,7 @@ module Blacksmith
     end
 
     def git_cmd_with_path(cmd)
+      cmd = cmd.split(' ') if cmd.is_a?String
       ["git", "--git-dir", File.join(path, '.git'), "--work-tree", path] + cmd
     end
 


### PR DESCRIPTION
This is not the best solution and should probably be fixed in a
different way, however, this is a working solution. There seem to be
methods that provide cmd as string, sometimes as array