### PR TITLE
Release 4.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ before_install:
   - git config --global user.email "user@example.com"
 
 rvm:
-  - '2.4'
   - '2.3'
   - '2.2'
   - '2.1'
   - '2.0'
+matrix:
+  include:
+    - rvm: '2.4'
+      env: DEPLOY_TO_FORGE=yes
 deploy:
   provider: rubygems
   api_key:
@@ -18,6 +21,7 @@ deploy:
   on:
     tags: true
     repo: voxpupuli/puppet-blacksmith
+    condition: "$DEPLOY_TO_FORGE = yes"
 
 notifications:
   email: false

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.2
+
+* Fix an incorrect checksum on rubygems
+
 ## 4.1.1
 
 * Expose `tag_sign` option in the RakeTask

--- a/lib/puppet_blacksmith/version.rb
+++ b/lib/puppet_blacksmith/version.rb
@@ -1,3 +1,3 @@
 module Blacksmith
-  VERSION = '4.1.1'
+  VERSION = '4.1.2'
 end


### PR DESCRIPTION
Something went wrong with the 4.1.1 release that resulted in an incorrect checksum on rubygems. Possible that's because we have multiple jobs attempting to release so it could have been some concurrency issue. This updates the Travis config to only deploy once.

Closes GH-60