### PR TITLE
Handle RC versions while patching

### DIFF
--- a/lib/puppet_blacksmith/version_helper.rb
+++ b/lib/puppet_blacksmith/version_helper.rb
@@ -115,9 +115,11 @@ module Blacksmith
 
       def increment!(term)
         new_version = clone
-        new_value = send(term) + 1
 
-        new_version.send("#{term}=", new_value)
+        if term != :patch || @pre.nil?
+          new_version.send("#{term}=", send(term) + 1)
+        end
+
         new_version.minor = 0 if term == :major
         new_version.patch = 0 if term == :major || term == :minor
         new_version.build = new_version.pre = nil

--- a/spec/data/metadata.json
+++ b/spec/data/metadata.json
@@ -28,9 +28,9 @@
   "description": "Standard Library for Puppet Modules",
   "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
   "dependencies": [
-      {
-          "name": "puppetlabs-stdlib",
-          "version_requirement": ">= 3.0.0"
-      }
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 3.0.0"
+    }
   ]
 }

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -116,8 +116,8 @@ describe 'Blacksmith::Modulefile' do
   describe 'increase_version' do
     it { expect(subject.increase_version("1.0.0")).to eql("1.0.1") }
     it { expect(subject.increase_version("1.0.1")).to eql("1.0.2") }
-    it { expect { subject.increase_version("1.0") }.to raise_error }
-    it { expect { subject.increase_version("1.0.12qwe") }.to raise_error }
+    it { expect { subject.increase_version("1.0") }.to raise_error(ArgumentError) }
+    it { expect { subject.increase_version("1.0.12qwe") }.to raise_error(ArgumentError) }
   end
 
   describe 'bump patch version' do

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -124,17 +124,20 @@ describe 'Blacksmith::Modulefile' do
     it { expect(subject.increase_version("1.0.0", :patch)).to eql("1.0.1") }
     it { expect(subject.increase_version("1.1.0", :patch)).to eql("1.1.1") }
     it { expect(subject.increase_version("1.1.1", :patch)).to eql("1.1.2") }
+    it { expect(subject.increase_version("1.1.2-rc0", :patch)).to eql("1.1.2") }
   end
 
   describe 'bump minor version' do
     it { expect(subject.increase_version("1.0.0", :minor)).to eql("1.1.0") }
     it { expect(subject.increase_version("1.1.0", :minor)).to eql("1.2.0") }
     it { expect(subject.increase_version("1.1.1", :minor)).to eql("1.2.0") }
+    it { expect(subject.increase_version("1.1.1-rc0", :minor)).to eql("1.2.0") }
   end
 
   describe 'bump major version' do
     it { expect(subject.increase_version("1.0.0", :major)).to eql("2.0.0") }
     it { expect(subject.increase_version("1.1.0", :major)).to eql("2.0.0") }
     it { expect(subject.increase_version("1.1.1", :major)).to eql("2.0.0") }
+    it { expect(subject.increase_version("1.1.1-rc0", :major)).to eql("2.0.0") }
   end
 end


### PR DESCRIPTION
Previously 1.2.3-rc0 bump would be increased to 1.2.4.

Also cleans up some testing code.