### PR TITLE
Update description for module:release task

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Rake tasks included:
 | module:clean       | Runs clean again |
 | module:dependency[modulename, version] | Updates the module version of a specific dependency |
 | module:push        | Push module to the Puppet Forge |
-| module:release     | Release the Puppet module, doing a clean, build, tag, push, bump_commit and git push |
+| module:release     | Release the Puppet module, doing a clean, build, bump_commit, tag, push and git push |
 | module:tag         | Git tag with the current module version |
 | module:version     | Get the current module version |
 | module:version:next | Get the next patch module version |

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -139,7 +139,7 @@ module Blacksmith
           Rake::Task["clean"].execute
         end
 
-        desc "Release the Puppet module, doing a clean, build, tag, push, bump_commit and git push."
+        desc "Release the Puppet module, doing a clean, build, bump_commit, tag, push and git push."
         release_dependencies = @build ? [:clean, :build, :bump_commit, :tag, :push] : [:clean, :bump_commit, :tag]
         task :release => release_dependencies do
           puts "Pushing to remote git repo"


### PR DESCRIPTION
Update description for `module:release` task to follow change in https://github.com/voxpupuli/puppet-blacksmith/pull/42 .