### PR TITLE
Remove Modulefile fixture

### DIFF
--- a/spec/data/Modulefile
+++ b/spec/data/Modulefile
@@ -1,9 +1,0 @@
-name 'maestrodev-test'
-version '1.0.0'
-
-license 'Apache License, Version 2.0'
-project_page 'http://github.com/maestrodev/puppet-blacksmith'
-source 'http://github.com/maestrodev/puppet-blacksmith'
-summary 'Testing Puppet module operations'
-description 'Testing Puppet module operations'
-dependency 'puppetlabs/stdlib', '>= 3.0.0'


### PR DESCRIPTION
914f35d2054591f50708912c9500351b775fe3a3 removed Modulefile support, but left in this fixture that's now unused.