### PR TITLE
(maint) Remove outdated variable reference

### DIFF
--- a/lib/puppet_blacksmith/forge.rb
+++ b/lib/puppet_blacksmith/forge.rb
@@ -51,14 +51,15 @@ module Blacksmith
     private
 
     def upload(author, name, file)
+      url = http_url(author, name, file)
       case forge_type
       when FORGE_TYPE_ARTIFACTORY
-        RestClient::Request.execute(:method => :put, :url => http_url(author, name, file), :payload => File.new(file, 'rb'), :headers => http_headers)
+        RestClient::Request.execute(:method => :put, :url => url, :payload => File.new(file, 'rb'), :headers => http_headers)
       else
-        RestClient::Request.execute(:method => :post, :url => http_url(author, name, file), :payload => {:file => File.new(file, 'rb')}, :headers => http_headers)
+        RestClient::Request.execute(:method => :post, :url => url, :payload => {:file => File.new(file, 'rb')}, :headers => http_headers)
       end
     rescue RestClient::Exception => e
-      raise Blacksmith::Error, "Error uploading #{package} to the forge #{url} [#{e.message}]: #{e.response}"
+      raise Blacksmith::Error, "Error uploading #{name} to the forge #{url} [#{e.message}]: #{e.response}"
     end
 
     def http_url(author, name, file)


### PR DESCRIPTION
The `upload` method in the `forge.rb` class was refactored, but one
error message that relied on variables which used to be defined in the
method was not updated with the new variables that are in scope for the
method. This removes the variables that now refer to nothing (and thus
throw and error when they're referenced), and replaces them with
variables that are in scope for the `upload` function.

Closes GH-74