### PR TITLE
Use the modern cucumber syntax

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,2 +1,2 @@
 ---
-default: --tags ~@skip
+default: --tags "not @skip"


### PR DESCRIPTION
This avoids a deprecation warning.