### PR TITLE
Drop old gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem 'public_suffix', '< 3' if RUBY_VERSION < '2.1'


### PR DESCRIPTION
Since 5.0.0 the minimum Ruby version is 2.4 so this condition is never true.