### PR TITLE
Forge upload should always use namespace

### DIFF
--- a/lib/puppet_blacksmith/modulefile.rb
+++ b/lib/puppet_blacksmith/modulefile.rb
@@ -21,6 +21,9 @@ module Blacksmith
     def name
       metadata['name'].split('-',2)[1]
     end
+    def namespace
+      metadata['name'].split('-',2)[0]
+    end
     def author
       metadata['author'] || metadata['name'].split('-',2)[0]
     end

--- a/lib/puppet_blacksmith/modulefile.rb
+++ b/lib/puppet_blacksmith/modulefile.rb
@@ -25,7 +25,7 @@ module Blacksmith
       metadata['name'].split('-',2)[0]
     end
     def author
-      metadata['author'] || metadata['name'].split('-',2)[0]
+      metadata['author'] || namespace
     end
     def version
       metadata['version']

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -138,8 +138,8 @@ module Blacksmith
         task :push => :'module:build' do
           m = Blacksmith::Modulefile.new
           forge = Blacksmith::Forge.new
-          puts "Uploading to Puppet Forge #{m.author}/#{m.name}"
-          forge.push!(m.name, nil, m.author, m.version)
+          puts "Uploading to Puppet Forge #{m.namespace}/#{m.name}"
+          forge.push!(m.name, nil, m.namespace, m.version)
         end
 
         desc "Runs clean again"

--- a/spec/data/metadata-different-author.json
+++ b/spec/data/metadata-different-author.json
@@ -1,0 +1,36 @@
+{
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.2.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=2.7.20 <7.0.0"
+    }
+  ],
+  "name": "maestrodev-test",
+  "version": "1.0.0",
+  "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+  "author": "MaestroDev",
+  "license": "Apache 2.0",
+  "summary": "Puppet Module Standard Library",
+  "description": "Standard Library for Puppet Modules",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 3.0.0"
+    }
+  ]
+}

--- a/spec/data/metadata-no-author.json
+++ b/spec/data/metadata-no-author.json
@@ -1,0 +1,35 @@
+{
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.2.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=2.7.20 <7.0.0"
+    }
+  ],
+  "name": "maestrodev-test",
+  "version": "1.0.0",
+  "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+  "license": "Apache 2.0",
+  "summary": "Puppet Module Standard Library",
+  "description": "Standard Library for Puppet Modules",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 3.0.0"
+    }
+  ]
+}

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -11,6 +11,32 @@ describe 'Blacksmith::Modulefile' do
     it { expect(subject.name).to eql("test") }
   end
 
+  context "using different author" do
+    let(:path) { "spec/data/metadata-different-author.json" }
+
+    subject { Blacksmith::Modulefile.new(path) }
+
+    it_behaves_like :metadata
+
+    describe "author and namespace" do
+      it { expect(subject.author).to eql("MaestroDev") }
+      it { expect(subject.namespace).to eql("maestrodev") }
+    end
+  end
+
+  context "using no author" do
+    let(:path) { "spec/data/metadata-no-author.json" }
+
+    subject { Blacksmith::Modulefile.new(path) }
+
+    it_behaves_like :metadata
+
+    describe "author and namespace" do
+      it { expect(subject.author).to eql("maestrodev") }
+      it { expect(subject.namespace).to eql("maestrodev") }
+    end
+  end
+
   context "using metadata.json" do
 
     it_behaves_like :metadata


### PR DESCRIPTION
There is an author field in metadata.json, but `pdk build` always uses
the module's namespace when building the tarball. Therefore, Blacksmith
should do the same and not even use the author field.