### PR TITLE
Use puppet-modulebuilder ~> 0.2

### DIFF
--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -60,7 +60,7 @@ module Blacksmith
         desc 'Build the module using puppet-modulebuilder'
         task :build do
           require 'puppet/modulebuilder'
-          builder = Puppet::Modulebuilder::Builder.new(Dir.pwd, nil, nil)
+          builder = Puppet::Modulebuilder::Builder.new(Dir.pwd)
           package_file = builder.build
           puts "Built #{package_file}"
         end

--- a/puppet-blacksmith.gemspec
+++ b/puppet-blacksmith.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
+  s.add_runtime_dependency 'puppet-modulebuilder', '~> 0.2'
   s.add_runtime_dependency 'rest-client', '~>2.0'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Version 0.2 has a slightly simpler API but more importantly, it always ignores .git which means a release doesn't accidentally upload the full git repo. Previously 0.2 was allowed, but this enforces it.