### PR TITLE
Remove oauth username/password login

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,19 @@ $ rake module:push
 
 #### Configuring to push a module to the Puppet Forge
 
-Configure your credentials in `~/.puppetforge.yml`
+Configure your credentials in `~/.puppetforge.yml`. You will need to generate a Forge API key on your user profile page.
 
 ```yaml
 ---
-username: myuser
-password: mypassword
+api_key: myAPIkey
 ```
 
-Or set the equivalent environment variables in your shell
+Or set the equivalent environment variable in your shell
 
 ```bash
-export BLACKSMITH_FORGE_USERNAME=myuser
-export BLACKSMITH_FORGE_PASSWORD=mypassword
+export BLACKSMITH_FORGE_API_KEY=myAPIkey
 ```
+
 
 #### Configuring to push a module to a JFrog Artifactory
 
@@ -123,7 +122,7 @@ export BLACKSMITH_FORGE_USERNAME=myuser
 export BLACKSMITH_FORGE_PASSWORD=mypassword
 ```
 
-Alternatively to username and password, an API Key can be used and set in the `puppetforge.yml`. API keys are retrieved from the website, whether it's the Forge or Artifactory.
+Alternatively, you can generate an API Key on the Artifactory profile page and us that in `puppetforge.yml`.
 
 ```yaml
 ---

--- a/lib/puppet_blacksmith/credentials.yml
+++ b/lib/puppet_blacksmith/credentials.yml
@@ -1,3 +1,0 @@
----
-client_id: "b93eb708fd942cfc7b4ed71db6ce219b814954619dbe537ddfd208584e8cff8d"
-client_secret: "216648059ad4afec3e4d77bd9e67817c095b2dcf94cdec18ac3d00584f863180"

--- a/lib/puppet_blacksmith/forge.rb
+++ b/lib/puppet_blacksmith/forge.rb
@@ -15,7 +15,7 @@ module Blacksmith
     DEFAULT_CREDENTIALS = { 'url' => PUPPETLABS_FORGE, 'forge_type' => FORGE_TYPE_PUPPET }
     HEADERS = { 'User-Agent' => "Blacksmith/#{Blacksmith::VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE}; #{RUBY_PLATFORM})" }
 
-    attr_accessor :username, :password, :url, :client_id, :client_secret, :forge_type, :token, :api_key
+    attr_accessor :username, :password, :url, :forge_type, :token, :api_key
 
     def initialize(username = nil, password = nil, url = nil, forge_type = nil, token = nil, api_key = nil)
       self.username = username
@@ -24,7 +24,6 @@ module Blacksmith
       self.api_key = api_key
       RestClient.proxy = ENV['http_proxy']
       load_credentials
-      load_client_credentials_from_file
       self.url = url unless url.nil?
       if self.url =~ %r{http(s)?://forge.puppetlabs.com}
         puts "Ignoring url entry in .puppetforge.yml: must point to the api server at #{PUPPETLABS_FORGE}, not the Forge webpage"
@@ -83,24 +82,8 @@ module Blacksmith
           HEADERS.merge({'Authorization' => "Basic " + Base64.strict_encode64("#{username}:#{password}")})
         end
       else
-        HEADERS.merge({'Authorization' => "Bearer #{api_key || token || oauth_access_token}"})
+        HEADERS.merge({'Authorization' => "Bearer #{api_key || token}"})
       end
-    end
-
-    def oauth_access_token
-      begin
-        response = RestClient.post("#{url}/oauth/token", {
-          'client_id' => client_id,
-          'client_secret' => client_secret,
-          'username' => username,
-          'password' => password,
-          'grant_type' => 'password'
-        }, HEADERS)
-      rescue RestClient::Exception => e
-        raise Blacksmith::Error, "Error login to the forge #{url} as #{username} [#{e.message}]: #{e.response}"
-      end
-      login_data = JSON.parse(response)
-      login_data['access_token']
     end
 
     def load_credentials
@@ -193,12 +176,6 @@ password: mypassword
       return credentials
     end
 
-    def load_client_credentials_from_file
-      credentials_file = File.expand_path(File.join(__FILE__, "..", "credentials.yml"))
-      credentials = YAML.load_file(credentials_file)
-      self.client_id = credentials['client_id']
-      self.client_secret = credentials['client_secret']
-    end
   end
 
 end

--- a/spec/puppet_blacksmith/forge_shared.rb
+++ b/spec/puppet_blacksmith/forge_shared.rb
@@ -9,6 +9,7 @@ end
 
 RSpec.shared_context "forge" do
   subject { Blacksmith::Forge.new(username, password, forge) }
+  let(:api_key) { 'e52f78b62e97cb8d8db6659a73aa522cca0f5c74d4714e0ed0bdd10000000000' }
   let(:username) { 'johndoe' }
   let(:password) { 'secret' }
   let(:forge) { "https://forgestagingapi.puppetlabs.com" }


### PR DESCRIPTION
This method for logging in to the Forge API is unsupported and not
guaranteed to remain stable. We should instruct users to generte an API
key instead.