### PR TITLE
remove unused puppet testing dependency

### DIFF
--- a/puppet-blacksmith.gemspec
+++ b/puppet-blacksmith.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rest-client', '~>2.0'
   s.add_development_dependency 'aruba', '~> 2.1'
   s.add_development_dependency 'cucumber', '>= 9', '< 11'
-  s.add_development_dependency 'puppet', '>= 7.24', '< 9'
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.12'
   s.add_development_dependency 'voxpupuli-rubocop', '~> 3.1.0'


### PR DESCRIPTION
All tests pass fine without it. @ekohl I didn't dig further down, maybe you remember why you moved puppet from a dependency to a dev dependency in #45. But I think it's safe to drop it now for real.